### PR TITLE
Update base Jenkins image to latest LTS w/latest plugins

### DIFF
--- a/local-jenkins/Dockerfile
+++ b/local-jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts-alpine@sha256:5ac4c620e28b0b62ba6ca715ddbca3f661fafd522a3983292b1f784ca1d2fa56
+FROM jenkins/jenkins:lts-alpine@sha256:8a18b4ae96f80d364d085375fc6d40f25ee16a8c6e4ae3d4d7e95bf14db48059
 
 ARG DOCKER_GID=974
 

--- a/local-jenkins/Dockerfile
+++ b/local-jenkins/Dockerfile
@@ -7,7 +7,6 @@ RUN addgroup -g ${DOCKER_GID} docker && addgroup jenkins docker
 
 USER jenkins
 RUN jenkins-plugin-cli --plugins \
-  build-monitor-plugin:1.13+build.202201031653 build-name-setter:2.2.0 \
-  docker-plugin:1.2.6 docker-workflow:1.26 http_request:1.12 \
-  pipeline-utility-steps:2.11.0 rebuild:1.32 remote-file:1.21 \
-  view-job-filters:2.3 ws-cleanup:0.40
+  build-monitor-plugin build-name-setter docker-plugin docker-workflow \
+  http_request pipeline-utility-steps rebuild remote-file view-job-filters \
+  ws-cleanup


### PR DESCRIPTION
Update the base image used for the local instance of Jenkins to the latest LTS version, `2.319.2`. Plugins downloaded at the time of building the image no longer have their version fixed on the image source, and instead will stay at their latest versions.